### PR TITLE
Sewe/4 implement basic substance screen

### DIFF
--- a/resq_tools/lib/blocs/substance_cubit.dart
+++ b/resq_tools/lib/blocs/substance_cubit.dart
@@ -1,23 +1,44 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:resq_tools/models/substance/substance_result.dart';
 import 'package:resq_tools/repositories/substance_repository.dart';
 
 class SubstanceState {
-  final String? dummyString;
-
+  final SubstanceResult? substance;
   final bool isLoading;
+  final bool isError;
 
-  const SubstanceState({this.dummyString, this.isLoading = false});
+  const SubstanceState({
+    this.substance,
+    this.isLoading = false,
+    this.isError = false,
+  });
+
+  SubstanceState copyWith({
+    SubstanceResult? substance,
+    bool? isLoading,
+    bool? isError,
+  }) {
+    return SubstanceState(
+      substance: substance ?? this.substance,
+      isLoading: isLoading ?? this.isLoading,
+      isError: isError ?? this.isError,
+    );
+  }
 }
 
 class SubstanceCubit extends Cubit<SubstanceState> {
   final SubstanceRepository substanceRepository;
 
-  SubstanceCubit(this.substanceRepository)
-    : super(const SubstanceState(isLoading: true)) {
-    fetch();
-  }
+  SubstanceCubit(this.substanceRepository) : super(const SubstanceState());
 
-  void fetch() {
-    emit(SubstanceState(dummyString: substanceRepository.getDummyString()));
+  Future<void> fetchSubstance(String substanceNumber) async {
+    emit(state.copyWith(isLoading: true, isError: false));
+
+    try {
+      final substance = await substanceRepository.fetchSubstance();
+      emit(SubstanceState(substance: substance));
+    } catch (error) {
+      emit(const SubstanceState(isError: true));
+    }
   }
 }

--- a/resq_tools/lib/blocs/substance_cubit.dart
+++ b/resq_tools/lib/blocs/substance_cubit.dart
@@ -34,10 +34,10 @@ class SubstanceCubit extends Cubit<SubstanceState> {
   Future<void> fetchSubstance(String substanceNumber) async {
     emit(state.copyWith(isLoading: true, isError: false));
 
-    try {
-      final substance = await substanceRepository.fetchSubstance();
+    final substance = await substanceRepository.fetchSubstance();
+    if (substance != null) {
       emit(SubstanceState(substance: substance));
-    } catch (error) {
+    } else {
       emit(const SubstanceState(isError: true));
     }
   }

--- a/resq_tools/lib/l10n/app_de.arb
+++ b/resq_tools/lib/l10n/app_de.arb
@@ -6,7 +6,7 @@
   "substance_title": "Gefahrgut",
   "blattler_title": "Blattler",
 
-  "resistance_weigth": "Gewicht (kN)",
+  "resistance_weight": "Gewicht (kN)",
   "resistance_gradient": "Steigung (°)",
   "resistance_angle": "Winkel",
   "resistance_rolling_resistance": "Rollwiderstand",

--- a/resq_tools/lib/l10n/app_de.arb
+++ b/resq_tools/lib/l10n/app_de.arb
@@ -27,5 +27,12 @@
   "resistance_underground_type_up_to_wheels_in_mud": "Über Räder im Schlamm",
   "resistance_underground_type_up_to_body_in_mud": "Über Aufbau im Schlamm",
   "resistance_underground_type_rail": "Schiene",
-  "resistance_start_calculation": "Messung starten"
+  "resistance_start_calculation": "Messung starten",
+
+  "substance_textfield_label": "Gefahrnummer / UN-Nummer",
+  "substance_name": "Name",
+  "substance_hazard_number": "Gefahrnummer",
+  "substance_un_number": "UN-Nummer",
+  "substance_properties": "Eigenschaften",
+  "substance_search": "Suche"
 }

--- a/resq_tools/lib/l10n/app_en.arb
+++ b/resq_tools/lib/l10n/app_en.arb
@@ -27,5 +27,12 @@
   "resistance_underground_type_up_to_wheels_in_mud": "Up to wheels in mud",
   "resistance_underground_type_up_to_body_in_mud": "Up to body in mud",
   "resistance_underground_type_rail": "Rail",
-  "resistance_start_calculation": "Start measurement"
+  "resistance_start_calculation": "Start measurement",
+
+  "substance_textfield_label": "Hazard number / UN-Number",
+  "substance_name": "Name",
+  "substance_hazard_number": "Hazard number",
+  "substance_un_number": "UN-Number",
+  "substance_properties": "Properties",
+  "substance_search": "Search"
 }

--- a/resq_tools/lib/l10n/app_en.arb
+++ b/resq_tools/lib/l10n/app_en.arb
@@ -6,7 +6,7 @@
   "substance_title": "Substance",
   "blattler_title": "Blattler",
 
-  "resistance_weigth": "Weight (kN)",
+  "resistance_weight": "Weight (kN)",
   "resistance_gradient": "Gradient (°)",
   "resistance_angle": "Angle",
   "resistance_rolling_resistance": "Rolling resistance",

--- a/resq_tools/lib/models/substance/substance_result.dart
+++ b/resq_tools/lib/models/substance/substance_result.dart
@@ -1,0 +1,13 @@
+class SubstanceResult {
+  final String name;
+  final int hazardNumber;
+  final int unNumber;
+  final String properties;
+
+  const SubstanceResult({
+    required this.name,
+    required this.hazardNumber,
+    required this.unNumber,
+    required this.properties,
+  });
+}

--- a/resq_tools/lib/repositories/substance_repository.dart
+++ b/resq_tools/lib/repositories/substance_repository.dart
@@ -1,5 +1,15 @@
+import 'package:resq_tools/models/substance/substance_result.dart';
+
 class SubstanceRepository {
-  String getDummyString() {
-    return 'I am from SubstanceRepository';
+  Future<SubstanceResult> fetchSubstance() async {
+    //TODO: make network request
+    await Future.delayed(const Duration(seconds: 1));
+
+    return SubstanceResult(
+      name: 'Benzin',
+      hazardNumber: 33,
+      unNumber: 1203,
+      properties: 'Extrem entzündbare Flüssigkeit',
+    );
   }
 }

--- a/resq_tools/lib/repositories/substance_repository.dart
+++ b/resq_tools/lib/repositories/substance_repository.dart
@@ -1,15 +1,18 @@
 import 'package:resq_tools/models/substance/substance_result.dart';
 
 class SubstanceRepository {
-  Future<SubstanceResult> fetchSubstance() async {
-    //TODO: make network request
-    await Future.delayed(const Duration(seconds: 1));
-
-    return SubstanceResult(
-      name: 'Benzin',
-      hazardNumber: 33,
-      unNumber: 1203,
-      properties: 'Extrem entzündbare Flüssigkeit',
-    );
+  Future<SubstanceResult?> fetchSubstance() async {
+    try {
+      //TODO: make network request
+      await Future.delayed(const Duration(seconds: 1));
+      return SubstanceResult(
+        name: 'Benzin',
+        hazardNumber: 33,
+        unNumber: 1203,
+        properties: 'Extrem entzündbare Flüssigkeit',
+      );
+    } catch (e) {
+      return null;
+    }
   }
 }

--- a/resq_tools/lib/screens/resistance_screen.dart
+++ b/resq_tools/lib/screens/resistance_screen.dart
@@ -72,9 +72,9 @@ class _ResistanceScreenState extends State<ResistanceScreen> {
             keyboardType: TextInputType.number,
             decoration: InputDecoration(
               border: const OutlineInputBorder(),
-              hintText: context.l10n?.resistance_weigth,
+              hintText: context.l10n?.resistance_weight,
               floatingLabelBehavior: FloatingLabelBehavior.always,
-              labelText: context.l10n?.resistance_weigth,
+              labelText: context.l10n?.resistance_weight,
             ),
             onChanged: (value) {
               setState(() {

--- a/resq_tools/lib/screens/substance_screen.dart
+++ b/resq_tools/lib/screens/substance_screen.dart
@@ -2,23 +2,163 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:resq_tools/blocs/substance_cubit.dart';
 import 'package:resq_tools/utils/extensions.dart';
+import 'package:resq_tools/models/substance/substance_result.dart';
 
-class SubstanceScreen extends StatelessWidget {
+class SubstanceScreen extends StatefulWidget {
   const SubstanceScreen({super.key});
+
+  @override
+  State<SubstanceScreen> createState() => _SubstanceScreenState();
+}
+
+class _SubstanceScreenState extends State<SubstanceScreen> {
+  final TextEditingController _textEditingController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(context.l10n?.substance_title ?? '')),
-      body: Center(
-        child: BlocBuilder<SubstanceCubit, SubstanceState>(
-          builder: (context, state) {
-            return state.isLoading
-                ? const CircularProgressIndicator()
-                : Text(state.dummyString ?? 'No data');
-          },
+      appBar: AppBar(title: Text('${context.l10n?.substance_title}')),
+      body: BlocBuilder<SubstanceCubit, SubstanceState>(
+        builder: (context, state) {
+          return _getSubstanceWidget(context, state);
+        },
+      ),
+    );
+  }
+
+  Widget _getSubstanceWidget(BuildContext context, SubstanceState state) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 24.0, horizontal: 16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _showSubstanceSearchContainer(context),
+
+            const SizedBox(height: 48),
+
+            _showSubstanceResult(context, state),
+          ],
         ),
       ),
+    );
+  }
+
+  Widget _showSubstanceSearchContainer(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _textEditingController,
+                keyboardType: TextInputType.number,
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  labelText: context.l10n?.substance_textfield_label,
+                ),
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.camera_alt),
+              onPressed: () {
+                // TODO: implement camera
+              },
+            ),
+          ],
+        ),
+
+        Padding(
+          padding: EdgeInsets.only(top: 16.0),
+          child: FilledButton(
+            onPressed: () {
+              // Trigger search in your cubit:
+              context.read<SubstanceCubit>().fetchSubstance(
+                _textEditingController.text,
+              );
+            },
+            child: Text('${context.l10n?.substance_search}'),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _showSubstanceResult(BuildContext context, SubstanceState state) {
+    final substance = state.substance;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (state.isError)
+          const Text('An error occurred', style: TextStyle(color: Colors.red))
+        else if (state.isLoading)
+          const Center(child: CircularProgressIndicator())
+        else if (substance != null)
+          _showSubstanceDetails(context, substance),
+      ],
+    );
+  }
+
+  Widget _showSubstanceDetails(BuildContext context, SubstanceResult substance) {
+    final l10n = context.l10n;
+
+    const double textFontSize = 16.0;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text.rich(
+          TextSpan(
+            style: TextStyle(fontSize: textFontSize),
+            children: [
+              TextSpan(
+                text: '${l10n?.substance_name}: ',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              TextSpan(text: substance.name),
+            ],
+          ),
+        ),
+        Text.rich(
+          TextSpan(
+            style: TextStyle(fontSize: textFontSize),
+            children: [
+              TextSpan(
+                text: '${l10n?.substance_hazard_number}: ',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              TextSpan(text: '${substance.hazardNumber}'),
+            ],
+          ),
+        ),
+        Text.rich(
+          TextSpan(
+            style: TextStyle(fontSize: textFontSize),
+            children: [
+              TextSpan(
+                text: '${l10n?.substance_un_number}: ',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              TextSpan(text: '${substance.unNumber}'),
+            ],
+          ),
+        ),
+        Text.rich(
+          TextSpan(
+            style: TextStyle(fontSize: textFontSize),
+            children: [
+              TextSpan(
+                text: '${l10n?.substance_properties}: ',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              TextSpan(text: substance.properties),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/resq_tools/lib/screens/substance_screen.dart
+++ b/resq_tools/lib/screens/substance_screen.dart
@@ -74,7 +74,6 @@ class _SubstanceScreenState extends State<SubstanceScreen> {
           padding: EdgeInsets.only(top: 16.0),
           child: FilledButton(
             onPressed: () {
-              // Trigger search in your cubit:
               context.read<SubstanceCubit>().fetchSubstance(
                 _textEditingController.text,
               );


### PR DESCRIPTION
Basic dummy substance screen implementation. Currently, no network request - displaying mock data.

![image](https://github.com/user-attachments/assets/138c0ec7-8ec6-482b-b10a-90caecbb4de8)

Closes #4 