### PR TITLE
GH-64: add settings screen

### DIFF
--- a/resq_tools/lib/blocs/settings_cubit.dart
+++ b/resq_tools/lib/blocs/settings_cubit.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:resq_tools/repositories/settings_repository.dart';
+
+class SettingsState {
+  final ThemeMode themeMode;
+
+  const SettingsState({required this.themeMode});
+
+  SettingsState copyWith({ThemeMode? themeMode}) {
+    return SettingsState(themeMode: themeMode ?? this.themeMode);
+  }
+}
+
+class SettingsCubit extends Cubit<SettingsState> {
+  final SettingsRepository repository;
+
+  SettingsCubit(this.repository)
+    : super(const SettingsState(themeMode: ThemeMode.system)) {
+    _loadSettings();
+  }
+
+  Future<void> _loadSettings() async {
+    final savedState = await repository.loadSettings();
+    emit(savedState);
+  }
+
+  void setThemeMode(ThemeMode mode) {
+    final newState = state.copyWith(themeMode: mode);
+    repository.saveSettings(newState);
+    emit(newState);
+  }
+}

--- a/resq_tools/lib/constants/shared_pref_keys.dart
+++ b/resq_tools/lib/constants/shared_pref_keys.dart
@@ -1,0 +1,3 @@
+class SharedPrefsKeys {
+  static const String themeMode = 'theme_mode';
+}

--- a/resq_tools/lib/l10n/app_de.arb
+++ b/resq_tools/lib/l10n/app_de.arb
@@ -5,6 +5,7 @@
   "resistance_title": "Widerstand",
   "substance_title": "Gefahrgut",
   "blattler_title": "Blattler",
+  "settings_title": "Einstellungen",
 
   "rescue_sheet_textfield_label": "Kennzeichen (SD-123AB)",
   "rescue_sheet_textfield_error_invalid": "Ungültiges Kennzeichen",
@@ -88,5 +89,12 @@
   "onboarding_app_token_hint": "Geben Sie hier Ihren Token ein",
   "onboarding_set_token": "Token speichern",
   "onboarding_set_token_later": "Später",
-  "onboarding_demo_system": "Demosystem"
+  "onboarding_demo_system": "Demosystem",
+
+  "settings_item_change_token": "Token ändern",
+  "settings_item_change_token_subtitle": "Feuerwehr App Token",
+  "settings_item_theme": "Darstellung",
+  "settings_item_theme_system_default": "Systemstandard",
+  "settings_item_theme_light": "Hell",
+  "settings_item_theme_dark": "Dunkel"
 }

--- a/resq_tools/lib/l10n/app_en.arb
+++ b/resq_tools/lib/l10n/app_en.arb
@@ -5,6 +5,7 @@
   "resistance_title": "Resistance",
   "substance_title": "Substance",
   "blattler_title": "Blattler",
+  "settings_title": "Settings",
 
   "rescue_sheet_textfield_label": "Licence plate (SD-123AB)",
   "rescue_sheet_textfield_error_invalid": "Invalid licence plate",
@@ -88,5 +89,12 @@
   "onboarding_app_token_hint": "Enter your token here",
   "onboarding_set_token": "Set token",
   "onboarding_set_token_later": "Later",
-  "onboarding_demo_system": "Demo system"
+  "onboarding_demo_system": "Demo system",
+
+  "settings_item_change_token": "Change Token",
+  "settings_item_change_token_subtitle": "Feuerwehr App Token",
+  "settings_item_theme": "Appearance",
+  "settings_item_theme_system_default": "System default",
+  "settings_item_theme_light": "Light",
+  "settings_item_theme_dark": "Dark"
 }

--- a/resq_tools/lib/models/common/bottom_sheet_item.dart
+++ b/resq_tools/lib/models/common/bottom_sheet_item.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class BottomSheetItem {
+  final String title;
+  final IconData icon;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  BottomSheetItem({
+    required this.title,
+    required this.icon,
+    required this.isSelected,
+    required this.onTap,
+  });
+}

--- a/resq_tools/lib/models/settings/settings_item.dart
+++ b/resq_tools/lib/models/settings/settings_item.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class SettingsItem {
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  SettingsItem({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.onTap,
+  });
+}

--- a/resq_tools/lib/repositories/settings_repository.dart
+++ b/resq_tools/lib/repositories/settings_repository.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:resq_tools/blocs/settings_cubit.dart';
+import 'package:resq_tools/constants/shared_pref_keys.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SettingsRepository {
+  Future<SettingsState> loadSettings() async {
+    final sharedPrefs = await SharedPreferences.getInstance();
+    final savedThemeString =
+        sharedPrefs.getString(SharedPrefsKeys.themeMode) ??
+        ThemeMode.system.name;
+    final theme = ThemeMode.values.firstWhere(
+      (theme) => savedThemeString == theme.name,
+      orElse: () => ThemeMode.system,
+    );
+
+    return SettingsState(themeMode: theme);
+  }
+
+  Future<void> saveSettings(SettingsState state) async {
+    final sharedPrefs = await SharedPreferences.getInstance();
+    await sharedPrefs.setString(
+      SharedPrefsKeys.themeMode,
+      state.themeMode.name,
+    );
+  }
+}

--- a/resq_tools/lib/screens/blattler_screen.dart
+++ b/resq_tools/lib/screens/blattler_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:resq_tools/blocs/blattler_cubit.dart';
+import 'package:resq_tools/screens/settings_screen.dart';
 import 'package:resq_tools/utils/extensions.dart';
 import 'package:syncfusion_flutter_pdfviewer/pdfviewer.dart';
 
@@ -12,7 +13,6 @@ class BlattlerScreen extends StatefulWidget {
 }
 
 class _BlattlerScreenState extends State<BlattlerScreen> {
-
   final PdfViewerController _pdfViewerController = PdfViewerController();
   final TextEditingController _searchController = TextEditingController();
   late PdfTextSearchResult _searchResult;
@@ -32,24 +32,20 @@ class _BlattlerScreenState extends State<BlattlerScreen> {
       appBar: AppBar(
         title: Text(context.l10n?.blattler_title ?? 'Blattler'),
         actions: [
-          IconButton(
-            icon: const Icon(Icons.search),
-            onPressed: () {
-              _openSearchDialog(context);
-            },
-          ),
           if (_searchResult.hasResult) ...[
             IconButton(
               icon: const Icon(Icons.navigate_before),
-              onPressed: _searchResult.hasResult
-                  ? () => _searchResult.previousInstance()
-                  : null,
+              onPressed:
+                  _searchResult.hasResult
+                      ? () => _searchResult.previousInstance()
+                      : null,
             ),
             IconButton(
               icon: const Icon(Icons.navigate_next),
-              onPressed: _searchResult.hasResult
-                  ? () => _searchResult.nextInstance()
-                  : null,
+              onPressed:
+                  _searchResult.hasResult
+                      ? () => _searchResult.nextInstance()
+                      : null,
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 40),
@@ -60,13 +56,29 @@ class _BlattlerScreenState extends State<BlattlerScreen> {
               ),
             ),
           ],
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: () {
+              _openSearchDialog(context);
+            },
+          ),
+          IconButton(
+            icon: Icon(Icons.settings),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SettingsScreen()),
+              );
+            },
+          ),
         ],
-        bottom: _isSearching
-            ? const PreferredSize(
-          preferredSize: Size.fromHeight(4),
-          child: LinearProgressIndicator(),
-        )
-            : null,
+        bottom:
+            _isSearching
+                ? const PreferredSize(
+                  preferredSize: Size.fromHeight(4),
+                  child: LinearProgressIndicator(),
+                )
+                : null,
       ),
       body: BlocBuilder<BlattlerCubit, BlattlerState>(
         builder: (context, state) {
@@ -81,9 +93,7 @@ class _BlattlerScreenState extends State<BlattlerScreen> {
                 onDocumentLoaded: _onDocumentLoaded,
               ),
               if (_isSearching)
-                const Center(
-                  child: CircularProgressIndicator(),
-                ),
+                const Center(child: CircularProgressIndicator()),
             ],
           );
         },
@@ -123,12 +133,13 @@ class _BlattlerScreenState extends State<BlattlerScreen> {
       _pdfViewerController.searchText('___dummyString123456789___');
     }
   }
+
   void _openSearchDialog(BuildContext context) {
     showDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) {
         return AlertDialog(
-          title:  Text(context.l10n?.blattler_search_header ?? 'Search in PDF'),
+          title: Text(context.l10n?.blattler_search_header ?? 'Search in PDF'),
           content: TextField(
             controller: _searchController,
             decoration: InputDecoration(
@@ -138,7 +149,7 @@ class _BlattlerScreenState extends State<BlattlerScreen> {
           ),
           actions: <Widget>[
             TextButton(
-              child:  Text(context.l10n?.blattler_cancel ?? 'Cancel'),
+              child: Text(context.l10n?.blattler_cancel ?? 'Cancel'),
               onPressed: () {
                 Navigator.of(dialogContext).pop();
               },
@@ -153,4 +164,3 @@ class _BlattlerScreenState extends State<BlattlerScreen> {
     );
   }
 }
-

--- a/resq_tools/lib/screens/rescue_sheet_screen.dart
+++ b/resq_tools/lib/screens/rescue_sheet_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:resq_tools/blocs/rescue_sheet_cubit.dart';
 import 'package:resq_tools/models/common/camera_ocr_type.dart';
-import 'package:resq_tools/screens/onboarding_screen.dart';
+import 'package:resq_tools/screens/settings_screen.dart';
 import 'package:resq_tools/utils/extensions.dart';
 import 'package:resq_tools/widgets/rescue_sheet/euro_rescue_car_widget.dart';
 import 'package:resq_tools/widgets/rescue_sheet/licence_plate_car_widget.dart';
@@ -27,11 +27,11 @@ class _RescueSheetScreenState extends State<RescueSheetScreen> {
       title: Text(context.l10n?.rescue_sheet_title ?? ''),
       actions: [
         IconButton(
-          icon: Icon(Icons.vpn_key),
+          icon: Icon(Icons.settings),
           onPressed: () {
-            Navigator.pushReplacement(
+            Navigator.push(
               context,
-              MaterialPageRoute(builder: (_) => const OnboardingScreen()),
+              MaterialPageRoute(builder: (_) => const SettingsScreen()),
             );
           },
         ),

--- a/resq_tools/lib/screens/rescue_sheet_screen.dart
+++ b/resq_tools/lib/screens/rescue_sheet_screen.dart
@@ -46,7 +46,7 @@ class _RescueSheetScreenState extends State<RescueSheetScreen> {
 
   Widget _getRescueSheetWidget(BuildContext context, RescueSheetState state) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 16.0),
+      padding: const EdgeInsets.symmetric(vertical: 24.0, horizontal: 16.0),
       child: ListView(
         children: [
           TextFieldCameraSearch(

--- a/resq_tools/lib/screens/resistance_screen.dart
+++ b/resq_tools/lib/screens/resistance_screen.dart
@@ -7,6 +7,7 @@ import 'package:resq_tools/models/resistance/resistance_result.dart';
 import 'package:resq_tools/models/resistance/underground_type.dart';
 import 'package:resq_tools/models/resistance/vehicle_type.dart';
 import 'package:resq_tools/screens/angle_measurement_screen.dart';
+import 'package:resq_tools/screens/settings_screen.dart';
 import 'package:resq_tools/utils/extensions.dart';
 
 class ResistanceScreen extends StatefulWidget {
@@ -42,7 +43,20 @@ class _ResistanceScreenState extends State<ResistanceScreen> {
 
   @override
   Widget build(BuildContext context) => Scaffold(
-    appBar: AppBar(title: Text(context.l10n?.resistance_title ?? '')),
+    appBar: AppBar(
+      title: Text(context.l10n?.resistance_title ?? ''),
+      actions: [
+        IconButton(
+          icon: Icon(Icons.settings),
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const SettingsScreen()),
+            );
+          },
+        ),
+      ],
+    ),
     body: BlocBuilder<ResistanceCubit, ResistanceState>(
       builder: (context, state) {
         return state.isLoading

--- a/resq_tools/lib/screens/settings_screen.dart
+++ b/resq_tools/lib/screens/settings_screen.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:resq_tools/blocs/settings_cubit.dart';
+import 'package:resq_tools/models/common/bottom_sheet_item.dart';
+import 'package:resq_tools/models/settings/settings_item.dart';
+import 'package:resq_tools/screens/onboarding_screen.dart';
+import 'package:resq_tools/utils/extensions.dart';
+import 'package:resq_tools/widgets/bottom_sheet_list.dart';
+
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('${context.l10n?.settings_title}')),
+      body: BlocBuilder<SettingsCubit, SettingsState>(
+        builder: (context, state) {
+          return _getSettingsWidget(context, state);
+        },
+      ),
+    );
+  }
+
+  Widget _getSettingsWidget(BuildContext context, SettingsState state) {
+    final settingsItems = <SettingsItem>[
+      SettingsItem(
+        title: '${context.l10n?.settings_item_theme}',
+        subtitle: state.themeMode.localizedName(context),
+        icon: _getThemeIcon(state.themeMode),
+        onTap: () => _showThemeBottomSheet(context, state),
+      ),
+      SettingsItem(
+        title: '${context.l10n?.settings_item_change_token}',
+        subtitle: '${context.l10n?.settings_item_change_token_subtitle}',
+        icon: Icons.key,
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const OnboardingScreen()),
+          );
+        },
+      ),
+    ];
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24.0, horizontal: 8.0),
+      child: ListView.builder(
+        itemCount: settingsItems.length,
+        itemBuilder: (context, index) {
+          final item = settingsItems[index];
+          return Card(
+            child: ListTile(
+              title: Text(
+                item.title,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              subtitle: Text(item.subtitle),
+              leading: Icon(item.icon),
+              onTap: item.onTap,
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  void _showThemeBottomSheet(BuildContext context, SettingsState state) {
+    final items = <ThemeMode, (String title, IconData icon)>{
+      ThemeMode.system: (
+        '${context.l10n?.settings_item_theme_system_default}',
+        _getThemeIcon(ThemeMode.system),
+      ),
+      ThemeMode.light: (
+        '${context.l10n?.settings_item_theme_light}',
+        _getThemeIcon(ThemeMode.light),
+      ),
+      ThemeMode.dark: (
+        '${context.l10n?.settings_item_theme_dark}',
+        _getThemeIcon(ThemeMode.dark),
+      ),
+    };
+
+    final currentThemeMode = state.themeMode;
+    final bottomSheetItems =
+        items.entries.map((entry) {
+          final theme = entry.key;
+          final (label, icon) = entry.value;
+
+          return BottomSheetItem(
+            title: label,
+            icon: icon,
+            isSelected: currentThemeMode == theme,
+            onTap: () {
+              context.read<SettingsCubit>().setThemeMode(theme);
+              Navigator.pop(context);
+            },
+          );
+        }).toList();
+
+    showModalBottomSheet(
+      context: context,
+      showDragHandle: true,
+      builder: (context) {
+        return BottomSheetList(items: bottomSheetItems);
+      },
+    );
+  }
+
+  IconData _getThemeIcon(ThemeMode mode) => switch (mode) {
+    ThemeMode.system => Icons.brightness_auto,
+    ThemeMode.light => Icons.light_mode,
+    ThemeMode.dark => Icons.dark_mode,
+  };
+}

--- a/resq_tools/lib/screens/substance_screen.dart
+++ b/resq_tools/lib/screens/substance_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:resq_tools/blocs/substance_cubit.dart';
 import 'package:resq_tools/models/common/camera_ocr_type.dart';
 import 'package:resq_tools/models/substance/substance_result.dart';
+import 'package:resq_tools/screens/settings_screen.dart';
 import 'package:resq_tools/utils/extensions.dart';
 import 'package:resq_tools/widgets/substance/substance_result_widget.dart';
 import 'package:resq_tools/widgets/text_field_camera_search.dart';
@@ -15,7 +16,20 @@ class SubstanceScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('${context.l10n?.substance_title}')),
+      appBar: AppBar(
+        title: Text('${context.l10n?.substance_title}'),
+        actions: [
+          IconButton(
+            icon: Icon(Icons.settings),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SettingsScreen()),
+              );
+            },
+          ),
+        ],
+      ),
       body: BlocBuilder<SubstanceCubit, SubstanceState>(
         builder: (context, state) {
           return _getSubstanceWidget(context, state);

--- a/resq_tools/lib/utils/extensions.dart
+++ b/resq_tools/lib/utils/extensions.dart
@@ -4,3 +4,13 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 extension BuildContextExtension on BuildContext {
   AppLocalizations? get l10n => AppLocalizations.of(this);
 }
+
+extension LocalizedThemeMode on ThemeMode {
+  String localizedName(BuildContext context) {
+    return switch (this) {
+      ThemeMode.system => '${context.l10n?.settings_item_theme_system_default}',
+      ThemeMode.light => '${context.l10n?.settings_item_theme_light}',
+      ThemeMode.dark => '${context.l10n?.settings_item_theme_dark}',
+    };
+  }
+}

--- a/resq_tools/lib/widgets/bottom_sheet_list.dart
+++ b/resq_tools/lib/widgets/bottom_sheet_list.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:resq_tools/models/common/bottom_sheet_item.dart';
+
+class BottomSheetList extends StatelessWidget {
+  final List<BottomSheetItem> items;
+
+  const BottomSheetList({super.key, required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children:
+            items.map((item) {
+              return ListTile(
+                leading: Icon(item.icon),
+                selected: item.isSelected,
+                title: Text(item.title),
+                trailing: item.isSelected ? const Icon(Icons.check) : null,
+                onTap: () {
+                  item.onTap();
+                  Navigator.pop(context);
+                },
+              );
+            }).toList(),
+      ),
+    );
+  }
+}

--- a/resq_tools/pubspec.lock
+++ b/resq_tools/pubspec.lock
@@ -677,6 +677,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "20cbd561f743a342c76c151d6ddb93a9ce6005751e7aa458baad3858bfbfb6ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.10"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/resq_tools/pubspec.yaml
+++ b/resq_tools/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   syncfusion_flutter_pdfviewer: ^29.1.35
   url_launcher: ^6.3.1
   image_picker: ^1.1.2
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
SettingsScreen with theme selection and change token item


**Possible TODOs:**
- OnThemeChange: currently navStack not saved - navigated back to homeScreen as app is being rebuilt, navStack could be saved, so user stays on settingsScreen
- TokenChange: current just navigates to onboardingScreen - could maybe be replaced by separate text field in settingsScreen

<img src="https://github.com/user-attachments/assets/f4b741db-6a9b-42e5-b299-e237e0fdd29f" width = "250" />
<img src="https://github.com/user-attachments/assets/c261ea4e-13a0-49c6-a759-6b8477d44ad6" width = "250" />
<img src="https://github.com/user-attachments/assets/445f4aa7-cc70-428e-ac9e-0d58d9504bd5" width = "250" />


<img src="https://github.com/user-attachments/assets/c1e4dcb5-512e-4a2e-a8cb-c76366d31b6b" width = "250" />
<img src="https://github.com/user-attachments/assets/92698b45-c163-40e6-91dc-f7630e8db115" width = "250" />
